### PR TITLE
Bugfix/issue27

### DIFF
--- a/parm/rtofs_glo.hycom.oanl.in
+++ b/parm/rtofs_glo.hycom.oanl.in
@@ -2,6 +2,7 @@
   bias_lmt    = 3., 8.,
   bias_opt    = 'tsuv',
   bias_wt     = 1.,
+  blist       = '4800009', '4800029',
   cluster(2)  = 2.,
   cluster(3)  = 2.,
   cluster(6)  = 2.,

--- a/ush/rtofs_ncoda_amsr_qc.sh
+++ b/ush/rtofs_ncoda_amsr_qc.sh
@@ -44,7 +44,7 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AMSR2*"
+   cmd="$ymd/sst/$ymd$k*L2P*AMSR2*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/amsr_$k.$cut_dtg
    else
@@ -55,7 +55,7 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AMSR2*"
+   cmd="$ymd/sst/$ymd$k*L2P*AMSR2*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/amsr_$k.$cut_dtg
    else
@@ -65,7 +65,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat amsr_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat amsr_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck amsr start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck amsr finish ncdump at $(date)
+
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No AMSR files to process."
    echo "AMSR.obs_control file will not be updated"

--- a/ush/rtofs_ncoda_goes_qc.sh
+++ b/ush/rtofs_ncoda_goes_qc.sh
@@ -44,13 +44,13 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*ABI_G16*"
+   cmd="$ymd/sst/$ymd$k*L2P*ABI_G16*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/g16_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*ABI_G17*"
+   cmd="$ymd/sst/$ymd$k*L2P*ABI_G17*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/g17_$k.$cut_dtg
    else
@@ -61,13 +61,13 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*ABI_G16*"
+   cmd="$ymd/sst/$ymd$k*L2P*ABI_G16*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/g16_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*ABI_G17*"
+   cmd="$ymd/sst/$ymd$k*L2P*ABI_G17*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/g17_$k.$cut_dtg
    else
@@ -77,7 +77,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat g16_*.$cut_dtg g17_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat g16_*.$cut_dtg g17_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck goes start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck goes finish ncdump at $(date)
+
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No GOES files to process."
    echo "GOES.obs_control file will not be updated"

--- a/ush/rtofs_ncoda_himawari_qc.sh
+++ b/ush/rtofs_ncoda_himawari_qc.sh
@@ -43,13 +43,13 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AHI_H08*"
+   cmd="$ymd/sst/$ymd$k*L2P*AHI_H08*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/h08_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AHI_H09*"
+   cmd="$ymd/sst/$ymd$k*L2P*AHI_H09*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/h09_$k.$cut_dtg
    else
@@ -60,13 +60,13 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AHI_H08*"
+   cmd="$ymd/sst/$ymd$k*L2P*AHI_H08*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/h08_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AHI_H09*"
+   cmd="$ymd/sst/$ymd$k*L2P*AHI_H09*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/h09_$k.$cut_dtg
    else
@@ -76,7 +76,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat h08_*.$cut_dtg h09_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat h08_*.$cut_dtg h09_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck himawari start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck himawari finish ncdump at $(date)
+
 if [[  ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No HIMAWARI files to process."
    echo "HIMAWARI.obs_control file will not be updated"

--- a/ush/rtofs_ncoda_jpss_qc.sh
+++ b/ush/rtofs_ncoda_jpss_qc.sh
@@ -44,7 +44,7 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_N20*"
+   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_N20*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/n20_$k.$cut_dtg
    else
@@ -55,7 +55,7 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_N20*"
+   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_N20*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/n20_$k.$cut_dtg
    else
@@ -65,7 +65,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat n20_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat n20_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck jpss start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck jpss finish ncdump at $(date)
+
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No VIIRS JPSS files to process."
    echo "JPSS_VIIRS.obs_control file will not be updated"

--- a/ush/rtofs_ncoda_metop_qc.sh
+++ b/ush/rtofs_ncoda_metop_qc.sh
@@ -44,19 +44,19 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MA*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MA*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mta_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MB*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MB*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mtb_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MC*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MC*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mtc_$k.$cut_dtg
    else
@@ -67,19 +67,19 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MA*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MA*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mta_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MB*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MB*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mtb_$k.$cut_dtg
    else
       echo "WARNING $cmd does not exist"
    fi
-   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MC*"
+   cmd="$ymd/sst/$ymd$k*L2P*AVHRRF_MC*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/mtc_$k.$cut_dtg
    else
@@ -89,7 +89,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat mta_*.$cut_dtg mtb_*.$cut_dtg mtc_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat mta_*.$cut_dtg mtb_*.$cut_dtg mtc_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck metop start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck metop finish ncdump at $(date)
+
 if [[ ! -f  acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No METOP files to process."
    echo "METOP.obs_control file will not be updated"

--- a/ush/rtofs_ncoda_npp_qc.sh
+++ b/ush/rtofs_ncoda_npp_qc.sh
@@ -44,7 +44,7 @@ cd $SST_DATA_DIR
 ymd=${prv_dtg:0:8}
 for k in 12 13 14 15 16 17 18 19 20 21 22 23
 do
-   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_NPP*"
+   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_NPP*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/npp_$k.$cut_dtg
    else
@@ -55,7 +55,7 @@ done
 ymd=${cut_dtg:0:8}
 for k in 00 01 02 03 04 05 06 07 08 09 10 11
 do
-   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_NPP*"
+   cmd="$ymd/sst/$ymd$k*L2P*VIIRS_NPP*.nc"
    if [ -s $cmd ] ; then
       ls $cmd > $log_dir/npp_$k.$cut_dtg
    else
@@ -65,7 +65,22 @@ done
 
 #   change to working directory
 cd $log_dir
-cat npp_*.$cut_dtg > acspo_sst_files.$cut_dtg
+cat npp_*.$cut_dtg > acspo_sst_files.${cut_dtg}_prelim
+
+echo timecheck npp start ncdump at $(date)
+while read line
+do
+  ncdump -k $SST_DATA_DIR/$line > /dev/null
+  ncrc=$?
+  if [ $ncrc -eq 0 ]
+  then
+     echo $line >> acspo_sst_files.$cut_dtg
+  else
+     echo "WARNING - file $SST_DATA_DIR/$line appears to be corrupt."
+  fi
+done < acspo_sst_files.${cut_dtg}_prelim
+echo timecheck npp finish ncdump at $(date)
+
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No VIIRS NPP files to process."
    echo "NPP_VIIRS.obs_control file will not be updated"

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -1,13 +1,13 @@
 export model=rtofs_glo
-export rtofs_glo_ver=v2.3.0
+export rtofs_glo_ver=v2.3.1
 export model_ver=${rtofs_glo_ver}
 
 export envar_ver=1.0
-export PrgEnv_intel_ver=8.2.0
-export craype_ver=2.7.13
+export PrgEnv_intel_ver=8.1.0
+export craype_ver=2.7.10
 export intel_ver=19.1.3.304
-export cray_mpich_ver=8.1.12
-export prod_util_ver=2.0.13
+export cray_mpich_ver=8.1.9
+export prod_util_ver=2.0.12
 export cray_libsci_ver=21.08.1.2
 
 export bacio_ver=2.4.1

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,28 +1,28 @@
 #export model=rtofs
-export rtofs_glo_ver=v2.3.0
+export rtofs_glo_ver=v2.3.1
 export model_ver=${rtofs_glo_ver}
 export version=${rtofs_glo_ver}
 
 export gfs_ver=v16.2
 
-export PrgEnv_intel_ver=8.2.0
-export craype_ver=2.7.13
+export PrgEnv_intel_ver=8.1.0
+export craype_ver=2.7.10
 export intel_ver=19.1.3.304
-export cray_mpich_ver=8.1.12
-export cray_pals_ver=1.1.3
+export cray_mpich_ver=8.1.9
+export cray_pals_ver=1.0.17
 export cfp_ver=2.0.4
 
-export g2_ver=3.4.5
-export g2c_ver=1.6.4
+export g2_ver=3.4.4
+export g2c_ver=1.6.2
 export bacio_ver=2.4.1
 export w3nco_ver=2.4.1
-export w3emc_ver=2.9.1
+export w3emc_ver=2.7.3
 export jasper_ver=2.0.25
 export libpng_ver=1.6.37
 export zlib_ver=1.2.11
 export netcdf3_ver=3.6.3
 
-export bufr_dump_ver=2.0.0
+export bufr_dump_ver=1.0.0
 export hdf5_ver=1.10.6
 export netcdf4_ver=4.7.4
 
@@ -32,16 +32,3 @@ export grib_util_ver=1.2.3
 
 export gempak_ver=7.14.1
 export cdo_ver=1.9.8
-
-
-# Use NCO canned data
-export SENDCANNEDDBN=YES
-#export DCOMROOT=/lfs/h1/ops/canned/dcom
-#export COMPATH=/lfs/h1/ops/canned/com/gfs
-#export PDY=20220313
-#export DATAFS=h1
-#export SENDDBN=NO
-#export SENDDBN_NTC=NO
-#export KEEPDATA=YES
-
-export DBNLOG=YES


### PR DESCRIPTION
- fix bug where a netcdf file is corrupt and the NCODA codes abort when attempting to read it. These corrupt netcdf files are weeded out beforehand with the ncdump command
- blacklist 2 gliders
- update module versions