### PR TITLE
Add HYCOM-tools as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "sorc/HYCOM_tools.fd"]
+	path = sorc/HYCOM_tools.fd
+	url = git@github.com:HYCOM/HYCOM-tools.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "sorc/HYCOM_tools.fd"]
 	path = sorc/HYCOM_tools.fd
-	url = git@github.com:HYCOM/HYCOM-tools.git
+	url = https://github.com/HYCOM/HYCOM-tools.git
 	branch = master


### PR DESCRIPTION
# Goal:
Add [HYCOM-tools](https://github.com/HYCOM/HYCOM-tools) as a submodule

# How to make it work?
`git clone --recursive -b sanAkel/add-HYCOM_tools git@github.com:NOAA-EMC/RTOFS_GLO.git` 

Once merged into the `develop` branch, the following will suffice:
`git clone --recursive git@github.com:NOAA-EMC/RTOFS_GLO.git` 

# Why?
HYCOM-tools allows us to:
- Convert binary (increment) files into netcdf formatted files.
- Convert HYCOM restart file into MOM6 restart- which is needed as RTOFS transitions to using [UFS.](https://github.com/ufs-community/ufs-weather-model)   

# Test:
Works on:
- wcoss-2: cactus.
- hera.