### PR TITLE
Add scripts to convert 2d increments in sea ice coverage, thickness and temperature

### DIFF
--- a/scripts/UFS_helpers/.gitignore
+++ b/scripts/UFS_helpers/.gitignore
@@ -1,0 +1,3 @@
+scratch/*
+
+__pycache__/*

--- a/scripts/UFS_helpers/README.md
+++ b/scripts/UFS_helpers/README.md
@@ -12,5 +12,23 @@ to a _future_ version (**v3.0**) that would use:
 
 | File name | Brief description |
 | :--       | --: |
+| `bin2nc_inc_fld.sh` | Main script to convert binary formatted increment file or full field to netcdf |
+| `convert_bin_nc_format.py` | Script that is called by the bin2nc_inc_fld.sh |
 | `set_py_modules.sh` | Set up python modules (on wcoss-2, those maintained within [EVS](https://github.com/NOAA-EMC/EVS)) |
+| `utils.py` | Functions that do (all the) work |
 
+# Example usage:
+
+- `./bin2nc_inc_fld.sh`: Echoes example usage.
+
+- `./convert_bin_nc_format.py -h`: Echoes example usage; must have python modules loaded (use `set_py_modules.sh`)
+  - Note that it has some defaults and required fields.
+
+- To convert `ice temperature` and `field`:
+  `./bin2nc_inc_fld.sh dwood /lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/ 20250331 icetmp fld`
+
+- To convert `ice coverage` and `increment`:
+  `./bin2nc_inc_fld.sh dwood /lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/ 20250331 icecov inc`
+
+- Same as above, but from RTOFS v2.4:
+  `./bin2nc_inc_fld.sh dwood /lfs/h1/ops/prod/com/rtofs/v2.4/ 20250401 icecov fld`

--- a/scripts/UFS_helpers/README.md
+++ b/scripts/UFS_helpers/README.md
@@ -1,0 +1,13 @@
+# What's here?
+  Scripts that aid in transitioing from RTOFS **v2.5** that uses:
+  - [HYCOM.](https://github.com/NOAA-EMC/HYCOM-src)
+  - [CICE4.](https://www2.cesm.ucar.edu/models/ccsm4.0/cice/doc/index.html)  
+  to a _future_ version (**v3.0**) that would use:
+  - [MOM6.](https://github.com/NOAA-EMC/MOM6)
+  - [CICE6.](https://github.com/NOAA-EMC/CICE)
+
+# Brief Description:
+
+| File name | Brief description |
+| :--       | --: |
+

--- a/scripts/UFS_helpers/README.md
+++ b/scripts/UFS_helpers/README.md
@@ -2,7 +2,9 @@
   Scripts that aid in transitioing from RTOFS **v2.5** that uses:
   - [HYCOM.](https://github.com/NOAA-EMC/HYCOM-src)
   - [CICE4.](https://www2.cesm.ucar.edu/models/ccsm4.0/cice/doc/index.html)  
-  to a _future_ version (**v3.0**) that would use:
+
+to a _future_ version (**v3.0**) that would use:
+
   - [MOM6.](https://github.com/NOAA-EMC/MOM6)
   - [CICE6.](https://github.com/NOAA-EMC/CICE)
 
@@ -10,4 +12,5 @@
 
 | File name | Brief description |
 | :--       | --: |
+| `set_py_modules.sh` | Set up python modules (on wcoss-2, those maintained within [EVS](https://github.com/NOAA-EMC/EVS)) |
 

--- a/scripts/UFS_helpers/bin2nc_inc_fld.sh
+++ b/scripts/UFS_helpers/bin2nc_inc_fld.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-if [ $# -lt 1 ]
+if [[ $# -lt 1 ]]
 then
   echo " "
   echo "Usage: "
-  echo $0 "machine_name, path_to_input_file, date"
+  echo "$0" "machine_name, path_to_input_file, date"
   echo " "
   echo "Allowed machine names: dwood (dogwood), cac (cactus)"
   exit 1

--- a/scripts/UFS_helpers/bin2nc_inc_fld.sh
+++ b/scripts/UFS_helpers/bin2nc_inc_fld.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]
+then
+  echo " "
+  echo "Usage: "
+  echo $0 "machine_name, path_to_input_file, date"
+  echo " "
+  echo "Allowed machine names: dwood (dogwood), cac (cactus)"
+  exit 1
+fi
+
+machName=$1
+inputPath=$2
+dataDate=$3
+
+# defaults
+topog_file="/lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/depth_GLBb0.08_09m11.nc"
+
+# load module(s) that provide python packages (xarray)
+source set_py_modules.sh ${machName}
+
+# work or scratch directory
+cwd=$(pwd)
+if [ -e ${cwd}/scratch ]
+then
+  /usr/bin/rm -rf ${cwd}/scratch
+fi
+/usr/bin/mkdir -p ${cwd}/scratch
+echo "Output will be in a new scratch directory: "
+echo ${cwd}"/scratch"
+
+# Check if there is topography file (needed) that is readable
+if [ -e ${topog_file} ]
+then
+# echo "Found topography file at: "${topog_file}
+  echo " "
+else
+  echo "A topography file is needed for this to work."
+  echo "See /lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/README_get_GLBb_topo.md for details."
+fi
+
+# convert format of file: bin to netcdf 
+#python driver.py ${dataDate} ${inputPath}
+

--- a/scripts/UFS_helpers/bin2nc_inc_fld.sh
+++ b/scripts/UFS_helpers/bin2nc_inc_fld.sh
@@ -1,45 +1,75 @@
 #!/bin/bash
 
-if [[ $# -lt 1 ]]
-then
+if [[ $# -lt 3 ]]; then
   echo " "
   echo "Usage: "
-  echo "$0" "machine_name, path_to_input_file, date"
+  echo "$0" "machine_name, path_to_input_files, date"
   echo " "
   echo "Allowed machine names: dwood (dogwood), cac (cactus)"
+  echo " "
+  echo "Example of path to input files: "
+  echo "/lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/"
+  echo " "
+  echo "Date example: 20250331"
+  echo " "
+  echo "Variable name, options: icecov or icethk or icetmp or mixlyr"
+  echo " "
+  echo "Type of field: inc (increment) or fld (full field)?"
+  echo " "
   exit 1
 fi
+echo " "
 
 machName=$1
 inputPath=$2
 dataDate=$3
+vName=$4
+fType=$5
 
 # defaults
 topog_file="/lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/depth_GLBb0.08_09m11.nc"
 
-# load module(s) that provide python packages (xarray)
-source set_py_modules.sh ${machName}
-
 # work or scratch directory
 cwd=$(pwd)
-if [ -e ${cwd}/scratch ]
-then
-  /usr/bin/rm -rf ${cwd}/scratch
+if [[ -e ${cwd}/scratch_${dataDate} ]]; then
+  /usr/bin/rm -rf ${cwd}/scratch_${dataDate}
 fi
-/usr/bin/mkdir -p ${cwd}/scratch
-echo "Output will be in a new scratch directory: "
-echo ${cwd}"/scratch"
+/usr/bin/mkdir -p ${cwd}/scratch_${dataDate}
+echo "Output will be saved in a new scratch directory: "
+echo ${cwd}"/scratch_${dataDate}"
 
 # Check if there is topography file (needed) that is readable
-if [ -e ${topog_file} ]
-then
-# echo "Found topography file at: "${topog_file}
+if [[ -e ${topog_file} ]]; then
+  echo " "
+  echo "Using topography file at: "
+  echo ${topog_file}
   echo " "
 else
   echo "A topography file is needed for this to work."
   echo "See /lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/README_get_GLBb_topo.md for details."
+  exit 2
 fi
 
-# convert format of file: bin to netcdf 
-#python convert_bin_nc_format.py ${dataDate} ${inputPath}
+# load module(s) that provide python packages (xarray)
+source ${cwd}/set_py_modules.sh ${machName}
 
+# convert format of file: bin to netcdf 
+${cwd}/./convert_bin_nc_format.py --proc_date ${dataDate} \
+                                  --data_path_pref ${inputPath} \
+                                  --output_path ${cwd}/scratch_${dataDate} \
+                                  --var_name ${vName} \
+                                  --file_type ${fType}
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
+
+ncFileCount=$(find ${cwd}/scratch_${dataDate}/*.nc | wc -l)
+if [[ ${ncFileCount} -gt 0 ]]; then
+  echo " "
+  echo "All done!"
+  exit 0
+else
+  echo "Something went wrong, check output or logs and try again."
+  exit 3
+fi

--- a/scripts/UFS_helpers/bin2nc_inc_fld.sh
+++ b/scripts/UFS_helpers/bin2nc_inc_fld.sh
@@ -41,5 +41,5 @@ else
 fi
 
 # convert format of file: bin to netcdf 
-#python driver.py ${dataDate} ${inputPath}
+#python convert_bin_nc_format.py ${dataDate} ${inputPath}
 

--- a/scripts/UFS_helpers/convert_bin_nc_format.py
+++ b/scripts/UFS_helpers/convert_bin_nc_format.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+"""
+
+Convert analysis increments or fields from NCODA analysis that from
+binary to netcdf format.
+
+"""
+
+from utils import gather_fNames, bin_to_nc_2d_incr
+
+# -- arg parse
+proc_date = "20250331"
+data_path_pref = "/lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/"
+data_path_suff = "ncoda/hycom_var/restart/"
+
+varName = "icecov" #"icethk" # "icetmp" # "mixlyr"
+varType = "sfc"
+fType = "inc" # "fld" or "inc"
+
+topo_fName = "/lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/depth_GLBb0.08_09m11.nc"
+
+# -- arg parse
+
+#--------------------------------------------------------------------------------------------------
+data_path, fNames = gather_fNames(data_path_pref, data_path_suff, proc_date, varName, fType, varType="sfc")
+print(f'\nFound following [{len(fNames)}] files of [{varName}].')
+
+# convert each binary formatted file to netcdf
+for iF, fName in enumerate(fNames):
+  bin_to_nc_2d_incr(data_path, fName, topo_fName)
+#--------------------------------------------------------------------------------------------------

--- a/scripts/UFS_helpers/convert_bin_nc_format.py
+++ b/scripts/UFS_helpers/convert_bin_nc_format.py
@@ -7,26 +7,66 @@ binary to netcdf format.
 
 """
 
+import argparse
 from utils import gather_fNames, bin_to_nc_2d_incr
 
-# -- arg parse
-proc_date = "20250331"
-data_path_pref = "/lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/"
-data_path_suff = "ncoda/hycom_var/restart/"
 
-varName = "icecov" #"icethk" # "icetmp" # "mixlyr"
-varType = "sfc"
-fType = "inc" # "fld" or "inc"
+# user inputs
+get_inputs = argparse.ArgumentParser(prog='\nconvert_bin_nc_format.py',\
+          description='To convert RTOFS-DA output from binary to netcdf format.',\
+          usage='%(prog)s [options]',\
+          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-topo_fName = "/lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/depth_GLBb0.08_09m11.nc"
+get_inputs.add_argument('--proc_date', type=str,\
+          help='RTOFS-DA output date', metavar='example: 20250331',\
+          required=True)
 
-# -- arg parse
+get_inputs.add_argument('--data_path_pref', type=str,\
+          help='Path to experiment',\
+          default="/lfs/h2/emc/couple/noscrub/dan.iredell/COMDIR1/prod/com/rtofs/v2.5/")
 
-#--------------------------------------------------------------------------------------------------
+get_inputs.add_argument('--data_path_suff', type=str,\
+          help='Path to NCODA output within data_path_pref',\
+          default="ncoda/hycom_var/restart/")
+
+get_inputs.add_argument('--var_name', type=str,\
+          help='2-d variable name: icecov or icethk or icetmp or mixlyr',\
+          default="icecov")
+
+get_inputs.add_argument('--var_type', type=str,\
+          help='type of variable: sfc or pre or lyr',\
+          default="sfc")
+
+get_inputs.add_argument('--file_type', type=str,\
+          help='(inc) increment or (fld) field',\
+          default="inc")
+
+get_inputs.add_argument('--output_path', type=str,\
+          help='Path to where output files are to be saved',\
+          required=True)
+
+get_inputs.add_argument('--topography_file', type=str,\
+          help='Path to topography file',\
+          default="/lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/depth_GLBb0.08_09m11.nc")
+
+args = get_inputs.parse_args()
+# --
+
+proc_date = args.proc_date
+data_path_pref = args.data_path_pref
+data_path_suff = args.data_path_suff
+
+varName = args.var_name
+varType = args.var_type
+fType = args.file_type
+output_path = args.output_path
+
+topo_fName = args.topography_file
+
+# Get names of binary files
 data_path, fNames = gather_fNames(data_path_pref, data_path_suff, proc_date, varName, fType, varType="sfc")
 print(f'\nFound following [{len(fNames)}] files of [{varName}].')
 
 # convert each binary formatted file to netcdf
 for iF, fName in enumerate(fNames):
-  bin_to_nc_2d_incr(data_path, fName, topo_fName)
-#--------------------------------------------------------------------------------------------------
+  bin_to_nc_2d_incr(data_path, fName, output_path, topo_fName)

--- a/scripts/UFS_helpers/set_py_modules.sh
+++ b/scripts/UFS_helpers/set_py_modules.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]
+then
+  echo " "
+  echo "Usage: "
+  echo $0 "machine name"
+  echo " "
+  echo "Allowed machine names: dwood, cac"
+  exit 1
+fi
+mach=$1
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "Purging all modules and loading EVS python"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
+
+if [ ${mach} == "dwood" ] ||\
+   [ ${mach} == "cac" ]
+then
+  export py_mod="ve/evs/2.0"
+  module use /apps/dev/modulefiles/
+fi
+
+module purge
+module load ${py_mod}
+module list

--- a/scripts/UFS_helpers/set_py_modules.sh
+++ b/scripts/UFS_helpers/set_py_modules.sh
@@ -11,18 +11,21 @@ then
 fi
 mach=$1
 
-echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-echo "Purging all modules and loading EVS python"
-echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
+echo " "
 
 if [ ${mach} == "dwood" ] ||\
    [ ${mach} == "cac" ]
 then
+  module reset
+
   export py_mod="ve/evs/2.0"
   module use /apps/dev/modulefiles/
+else
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "Purging all modules and loading EVS python"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  module purge
 fi
 
-module purge
 module load ${py_mod}
 module list

--- a/scripts/UFS_helpers/set_py_modules.sh
+++ b/scripts/UFS_helpers/set_py_modules.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [[ $# -lt 1 ]]
-then
+if [[ $# -lt 1 ]]; then
   echo " "
   echo "Usage: "
   echo "$0" "machine name"
@@ -13,9 +12,7 @@ mach=$1
 
 echo " "
 
-if [ ${mach} == "dwood" ] ||\
-   [ ${mach} == "cac" ]
-then
+if [[ (${mach} == "dwood")  ||  (${mach} == "cac") ]]; then
   module reset
 
   export py_mod="ve/evs/2.0"

--- a/scripts/UFS_helpers/set_py_modules.sh
+++ b/scripts/UFS_helpers/set_py_modules.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-if [ $# -lt 1 ]
+if [[ $# -lt 1 ]]
 then
   echo " "
   echo "Usage: "
-  echo $0 "machine name"
+  echo "$0" "machine name"
   echo " "
   echo "Allowed machine names: dwood, cac"
   exit 1

--- a/scripts/UFS_helpers/utils.py
+++ b/scripts/UFS_helpers/utils.py
@@ -32,13 +32,14 @@ def read_ncoda_increment_2d(data_path, fName_full):
 
   fName = fName_full.replace(data_path, "") # get rid of path from _full_ file name
 
-  vName =fName.split('_')[0] + ' ' + fName.split('_')[-1]
+  vName = fName.split('_')[0]
+  vName_full =vName + ' ' + fName.split('_')[-1]
   im, jm = [int(fName.split('_')[2][2:6]), int(fName.split('_')[2][7:11])]
   fDate = fName.split('_')[3]
   fDate = fDate[0:4] + '-' + fDate[4:6] + '-' + fDate[6:8]# + ':' + fDate[8:10] # Always at 00 UTC
   fTime = np.array([str(fDate)], dtype='datetime64')
 
-  print(f'\nReading RTOFS DA {vName} increment on\n{fTime} with [x,y] dim = {im,jm}.')
+  print(f'\nReading RTOFS DA {vName_full} on\n{fTime} with [x,y] dim = {im,jm}.')
 
   f = open(data_path + fName, 'rb')
   vals = []
@@ -49,7 +50,7 @@ def read_ncoda_increment_2d(data_path, fName_full):
   vals = dummy.reshape((jm,im))
   f.close()
 
-  return fName, vName, fTime, vals
+  return vName, fName, vName_full, fTime, vals
 
 def land_sea_mask(topo_fName, save_forLater=False):
 
@@ -70,25 +71,22 @@ def land_sea_mask(topo_fName, save_forLater=False):
 
   return ls_mask
 
-def bin_to_nc_2d_incr(data_path, fName, topo_fName):
+def bin_to_nc_2d_incr(data_path, fName, outPath, topo_fName):
 
   # Read binary increment file
-  fName_bin, vName, incDate, ice_cov = read_ncoda_increment_2d(data_path, fName)
-
-  # This increment in ice coverage is in percentage (why??!!)
-  ice_cov = ice_cov / 100 # convert it to [-1, 1]
+  vName, fName_bin, vName_full, incDate, vals = read_ncoda_increment_2d(data_path, fName)
 
   # Create a dataset using topography file as a template
   ds_inc= xr.open_dataset(topo_fName, decode_times=False)
-  ds_inc['ice_cov'] = (('Y', 'X'), ice_cov)
+  ds_inc[vName] = (('Y', 'X'), vals)
 
   ls_mask = land_sea_mask(topo_fName)
   # Make sure concentration over land = 0.
   # Land values will be made to nan anyway, so this is done only for sanity sake!
-  ds_inc['ice_cov'] = ds_inc.ice_cov * ls_mask.mask.squeeze()
+  ds_inc[vName] = ds_inc[vName] * ls_mask.mask.squeeze()
 
   # Apply the land sea mask created above
-  ds_inc['ice_cov'] = ds_inc.ice_cov.where(ls_mask.mask == 1, np.nan)
+  ds_inc[vName] = ds_inc[vName].where(ls_mask.mask == 1, np.nan)
 
   # Delete depth, fix attributes
   ds_inc = ds_inc.drop_vars(['depth', 'Date']) # drop bathymetry
@@ -98,12 +96,12 @@ def bin_to_nc_2d_incr(data_path, fName, topo_fName):
 
   # fix attributes
   #ds_inc = ds_inc.drop_attrs() # Won't work unless additional packages are install- can't on wcoss!
-  ds_inc.ice_cov.attrs['units'] = '1'
-  ds_inc.ice_cov.attrs['standard_name'] = vName
-  ds_inc.ice_cov.attrs['description'] = 'Increment in sea ice coverage or concentration'
+  ds_inc[vName].attrs['units'] = '1'
+  ds_inc[vName].attrs['standard_name'] = vName
+  ds_inc[vName].attrs['description'] = vName_full
   ds_inc.attrs['source'] = 'NCEP RTOFS v2.5'
 
-  print(ds_inc.ice_cov.attrs)
+  #print(ds_inc[vName].attrs)
 
-  ds_inc.to_netcdf(fName_bin+'.nc')
+  ds_inc.to_netcdf(outPath+'/'+fName_bin+'.nc')
   return ds_inc

--- a/scripts/UFS_helpers/utils.py
+++ b/scripts/UFS_helpers/utils.py
@@ -22,13 +22,15 @@ def gather_fNames(data_path_pref, data_path_suff, proc_date, varName, fType, var
    ncoda_fType = "analfld"
 
   data_path = data_path_pref + "rtofs.{}/".format(proc_date) + data_path_suff
-  print(f'Looking for {varName}_{varType}_*{ncoda_fType} files at path:\n{data_path}')
+  print(f'\nLooking for {varName}_{varType}_*{ncoda_fType} files at path:\n{data_path}')
   fNames = sorted( glob.glob( data_path + varName + "_" + varType + "*" + ncoda_fType))
-  print(fNames)
+  #print(fNames)
 
-  return fNames
+  return data_path, fNames
 
-def read_ncoda_increment_2d(data_path, fName):
+def read_ncoda_increment_2d(data_path, fName_full):
+
+  fName = fName_full.replace(data_path, "") # get rid of path from _full_ file name
 
   vName =fName.split('_')[0] + ' ' + fName.split('_')[-1]
   im, jm = [int(fName.split('_')[2][2:6]), int(fName.split('_')[2][7:11])]
@@ -36,7 +38,7 @@ def read_ncoda_increment_2d(data_path, fName):
   fDate = fDate[0:4] + '-' + fDate[4:6] + '-' + fDate[6:8]# + ':' + fDate[8:10] # Always at 00 UTC
   fTime = np.array([str(fDate)], dtype='datetime64')
 
-  print(f'\nReading RTOFS DA {vName} increment on\n{fTime} with [x,y] dim = {im,jm}.\n')
+  print(f'\nReading RTOFS DA {vName} increment on\n{fTime} with [x,y] dim = {im,jm}.')
 
   f = open(data_path + fName, 'rb')
   vals = []
@@ -47,7 +49,7 @@ def read_ncoda_increment_2d(data_path, fName):
   vals = dummy.reshape((jm,im))
   f.close()
 
-  return vName, fTime, vals
+  return fName, vName, fTime, vals
 
 def land_sea_mask(topo_fName, save_forLater=False):
 
@@ -71,7 +73,7 @@ def land_sea_mask(topo_fName, save_forLater=False):
 def bin_to_nc_2d_incr(data_path, fName, topo_fName):
 
   # Read binary increment file
-  vName, incDate, ice_cov = read_ncoda_increment_2d(data_path, fName)
+  fName_bin, vName, incDate, ice_cov = read_ncoda_increment_2d(data_path, fName)
 
   # This increment in ice coverage is in percentage (why??!!)
   ice_cov = ice_cov / 100 # convert it to [-1, 1]
@@ -98,8 +100,10 @@ def bin_to_nc_2d_incr(data_path, fName, topo_fName):
   #ds_inc = ds_inc.drop_attrs() # Won't work unless additional packages are install- can't on wcoss!
   ds_inc.ice_cov.attrs['units'] = '1'
   ds_inc.ice_cov.attrs['standard_name'] = vName
-  ds_inc.ice_cov.attrs['description'] = 'Increment in sea ice concentration'
+  ds_inc.ice_cov.attrs['description'] = 'Increment in sea ice coverage or concentration'
   ds_inc.attrs['source'] = 'NCEP RTOFS v2.5'
 
   print(ds_inc.ice_cov.attrs)
+
+  ds_inc.to_netcdf(fName_bin+'.nc')
   return ds_inc

--- a/scripts/UFS_helpers/utils.py
+++ b/scripts/UFS_helpers/utils.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+"""
+Helper utilities to process RTOFS analysis increments.
+
+Questions:
+  1. In each day's analysis, past 18 days of increments are saved.
+     Much of the date (if not all?) is same and is being repeated over and over!
+     Why are we duplicating files and seemingly wasting disk space?
+"""
+
+import os
+import glob as glob
+import xarray as xr
+import numpy as np
+
+def gather_fNames(data_path_pref, data_path_suff, proc_date, varName, fType, varType="sfc"):
+
+  if fType == "inc":
+   ncoda_fType = "analinc"
+  else:
+   ncoda_fType = "analfld"
+
+  data_path = data_path_pref + "rtofs.{}/".format(proc_date) + data_path_suff
+  print(f'Looking for {varName}_{varType}_*{ncoda_fType} files at path:\n{data_path}')
+  fNames = sorted( glob.glob( data_path + varName + "_" + varType + "*" + ncoda_fType))
+  print(fNames)
+
+  return fNames
+
+def read_ncoda_increment_2d(data_path, fName):
+
+  vName =fName.split('_')[0] + ' ' + fName.split('_')[-1]
+  im, jm = [int(fName.split('_')[2][2:6]), int(fName.split('_')[2][7:11])]
+  fDate = fName.split('_')[3]
+  fDate = fDate[0:4] + '-' + fDate[4:6] + '-' + fDate[6:8]# + ':' + fDate[8:10] # Always at 00 UTC
+  fTime = np.array([str(fDate)], dtype='datetime64')
+
+  print(f'\nReading RTOFS DA {vName} increment on\n{fTime} with [x,y] dim = {im,jm}.\n')
+
+  f = open(data_path + fName, 'rb')
+  vals = []
+  f.seek(0)
+  dummy = np.fromfile(f, dtype='>f',count=jm*im) # read 2d file (1 layer)
+  #dummy = dummy.reshape((jm,im))
+  #vals = np.copy(dummy)
+  vals = dummy.reshape((jm,im))
+  f.close()
+
+  return vName, fTime, vals
+
+def land_sea_mask(topo_fName, save_forLater=False):
+
+  """
+  Create a land-sea mask from bathymetry:
+  - land: 0
+  - sea: 1
+  """
+
+  ds_topo = xr.open_dataset(topo_fName, decode_times=False)
+  ls_mask = ds_topo.copy(deep=True)
+  ls_mask['depth'] = xr.where(np.isnan(ls_mask.depth), 0, 1)
+  ls_mask = ls_mask.rename({'depth':'mask'}) # rename 
+
+  if (save_forLater):
+    fName = 'ls_mask_' + topo_fName
+    ls_mask.to_netcdf(topo_fName) # This will work only for @sanAkel!
+
+  return ls_mask
+
+def bin_to_nc_2d_incr(data_path, fName, topo_fName):
+
+  # Read binary increment file
+  vName, incDate, ice_cov = read_ncoda_increment_2d(data_path, fName)
+
+  # This increment in ice coverage is in percentage (why??!!)
+  ice_cov = ice_cov / 100 # convert it to [-1, 1]
+
+  # Create a dataset using topography file as a template
+  ds_inc= xr.open_dataset(topo_fName, decode_times=False)
+  ds_inc['ice_cov'] = (('Y', 'X'), ice_cov)
+
+  ls_mask = land_sea_mask(topo_fName)
+  # Make sure concentration over land = 0.
+  # Land values will be made to nan anyway, so this is done only for sanity sake!
+  ds_inc['ice_cov'] = ds_inc.ice_cov * ls_mask.mask.squeeze()
+
+  # Apply the land sea mask created above
+  ds_inc['ice_cov'] = ds_inc.ice_cov.where(ls_mask.mask == 1, np.nan)
+
+  # Delete depth, fix attributes
+  ds_inc = ds_inc.drop_vars(['depth', 'Date']) # drop bathymetry
+
+  ds_inc=ds_inc.rename({'MT': 'time'}) # rename MT to time
+  ds_inc['time'] = incDate # add time value
+
+  # fix attributes
+  #ds_inc = ds_inc.drop_attrs() # Won't work unless additional packages are install- can't on wcoss!
+  ds_inc.ice_cov.attrs['units'] = '1'
+  ds_inc.ice_cov.attrs['standard_name'] = vName
+  ds_inc.ice_cov.attrs['description'] = 'Increment in sea ice concentration'
+  ds_inc.attrs['source'] = 'NCEP RTOFS v2.5'
+
+  print(ds_inc.ice_cov.attrs)
+  return ds_inc


### PR DESCRIPTION
This PR adds scripts to convert increments (or fields) from RTOFS-DA that are written out as binary files to netcdf formatted files.

CICE6 and MOM6 do not work with binary files, hence we need a way to convert to netcdf.

See [usage and documentation.](https://github.com/NOAA-EMC/RTOFS_GLO/blob/bin_nc_converter/scripts/UFS_helpers/README.md)

Verified that everything works as intended on WCOSS-2 (dogwood and cactus).

FYI: @zgarraffo this way we do not need to use hycom tools!

@aerorahul Appreciate your comments/suggestions.