### PR TITLE
Add NCO's parallel to the dashboard stats

### DIFF
--- a/scripts/UFS_helpers/config_archive_to_nc.yaml
+++ b/scripts/UFS_helpers/config_archive_to_nc.yaml
@@ -1,15 +1,15 @@
-# RTOFS systems: "v2p4" or "v2p5" or "v2p5_bad"
-system_name: "v2p5" 
+# RTOFS systems: "v2p4" or "v2p5" or "v2p5_bad" or "v2p5_nco"
+system_name: "v2p5_nco" 
 
 # Path to grid file.
 grid_file: /lfs/h2/emc/couple/noscrub/santha.akella/data_files/v2.5/topog/regional.grid.a
 
 # Path to where archive files are staged.
 # Following path is expected to have directories: "yyyymmdd/"
-input_path: /lfs/h2/emc/ptmp/santha.akella/data/rtofs/v2p5/
+input_path: /lfs/h2/emc/ptmp/santha.akella/data/rtofs/v2p5_nco/
 
-start_date: 2025-05-01
-end_date: 2025-05-22
+start_date: 2025-05-30
+end_date: 2025-06-06
 
 # Which archives to process? Must be one at a time: "n00".
 arch_type: rtofs_glo.t00z.n00.archs.
@@ -22,4 +22,4 @@ do_extraVars: True # True/False
 extra_variables: ['curr']
 
 # Output path where output: (nc) files, plots, etc, are to be saved.
-output_path: /lfs/h2/emc/ptmp/santha.akella/data/arch2nc/v2p5
+output_path: /lfs/h2/emc/ptmp/santha.akella/data/arch2nc/v2p5_nco

--- a/scripts/UFS_helpers/config_dashboard.yaml
+++ b/scripts/UFS_helpers/config_dashboard.yaml
@@ -16,7 +16,7 @@ units:
 systems:
   - v2p4
   - v2p5
-  - v2p5_bad
+  - v2p5_nco
 
 regions:
   - Global
@@ -37,13 +37,13 @@ plot_each: False
 compare_all: True
 
 v2p4:
- name: production
- data_path: /u/santha.akella/tmp/plot_converted_nc/scripts/UFS_helpers/scratch_v2p4
+ name: prod
+ data_path: /u/santha.akella/rtofs_02June2025/scripts/UFS_helpers/scratch_v2p4
 
 v2p5:
- name: parallel
- data_path: /u/santha.akella/tmp/plot_converted_nc/scripts/UFS_helpers/scratch_v2p5
+ name: para
+ data_path: /u/santha.akella/rtofs_02June2025/scripts/UFS_helpers/scratch_v2p5
 
-v2p5_bad:
- name: bad parallel
- data_path: /u/santha.akella/tmp/plot_converted_nc/scripts/UFS_helpers/scratch_v2p5_bad
+v2p5_nco:
+ name: NCO para
+ data_path: /u/santha.akella/rtofs_02June2025/scripts/UFS_helpers/scratch_v2p5_nco

--- a/scripts/UFS_helpers/get_dashboard_data.sh
+++ b/scripts/UFS_helpers/get_dashboard_data.sh
@@ -74,42 +74,49 @@ for i in $(seq 1 ${num_days}); do
   ./diagnostics_global.py --data_file ${fName} \
                           --varName ${varName} \
                           --output_path ${output_data_path} \
+                          --config_file ./plot_config_2d_field.yaml \
                           ${extra_args} 
 
   # Arctic
   ./diagnostics_arctic.py --data_file ${fName} \
                           --varName ${varName} \
                           --output_path ${output_data_path} \
+                          --config_file ./plot_config_2d_field.yaml \
                           ${extra_args} 
 
   # Antarctic
   ./diagnostics_antarctic.py --data_file ${fName} \
                              --varName ${varName} \
                              --output_path ${output_data_path} \
+                             --config_file ./plot_config_2d_field.yaml \
                              ${extra_args} 
 
   # Eq Pacific
   ./diagnostics_eq_pac.py --data_file ${fName} \
                           --varName ${varName} \
                           --output_path ${output_data_path} \
+                          --config_file ./plot_config_2d_field.yaml \
                           ${extra_args} 
 
   # Atlantic
   ./diagnostics_atlantic.py --data_file ${fName} \
                             --varName ${varName} \
                             --output_path ${output_data_path} \
+                            --config_file ./plot_config_2d_field.yaml \
                             ${extra_args} 
 
   # Tropics and extratropics
   ./diagnostics_tropics.py --data_file ${fName} \
                            --varName ${varName} \
                            --output_path ${output_data_path} \
+                           --config_file ./plot_config_2d_field.yaml \
                            ${extra_args} 
 
   # East Pacific (cut out region)
   ./diagnostics_e_pac.py --data_file ${fName} \
                          --varName ${varName} \
                          --output_path ${output_data_path} \
+                         --config_file ./plot_config_2d_field.yaml \
                            ${extra_args} 
 done
 echo " "

--- a/scripts/UFS_helpers/get_nco_test.sh
+++ b/scripts/UFS_helpers/get_nco_test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [[ $# -lt 4 ]]; then
+  echo " "
+  echo " Get data from parallel run by NCO."
+  echo " "
+  echo "Usage: "
+  echo "$0" "start_date num_days output_path_base file_type"
+  echo " "
+  echo " "
+  echo "Example inputs: "
+  echo "2025-05-29 8 v2p5 /lfs/h2/emc/ptmp/santha.akella/data/rtofs rtofs_glo.t00z.n00.archs."
+  echo " "
+  echo "Note: Data is NOT fetched for start_date, begin a day before, if needed."
+  echo " "
+  exit 1
+fi
+echo " "
+
+set -ux
+    
+start_date="$1" #"2025-05-29"
+num_days="$2" #8
+
+system_name="v2p5_nco"
+
+output_path_base="$4" #/lfs/h2/emc/ptmp/santha.akella/data/rtofs
+file_type="$5" #rtofs_glo.t00z.n00.archs.
+# --
+
+nco_para_path=/lfs/h1/ops/para/com/rtofs/v2.5/
+
+CMD1=cp
+
+for i in $(seq 1 ${num_days}); do
+  data_date=$(date -d "$start_date + $i days" "+%Y%m%d")
+
+  year=$(date -d "$start_date + $i days" "+%Y")
+  mon=$(date -d "$start_date + $i days" "+%m")
+  day=$(date -d "$start_date + $i days" "+%d")
+
+  nco_file1=${nco_para_path}/rtofs.${data_date}/${file_type}a
+  nco_file2=${nco_para_path}/rtofs.${data_date}/${file_type}b
+
+  echo " "
+  echo "Fetching data from NCO para for..." ${data_date}
+  echo " "
+
+  output_path=${output_path_base}/${system_name}/${data_date}
+  mkdir -p ${output_path}
+  cd ${output_path}
+
+  $CMD1 ${nco_file1} .
+  $CMD1 ${nco_file2} .
+  cd -
+
+done
+
+echo " "
+exit 0


### PR DESCRIPTION
This PR adds capability to include data from NCO's parallel (data dir: `/para/`) 
using `scripts/UFS_helpers/get_nco_test.sh`

Rest of the steps to create the dashboard are the [same as here.](https://github.com/NOAA-EMC/RTOFS_GLO/wiki/Dashboard-diagnostics#sequence-of-steps-to-create-dashboard) 