### PR TITLE
Remove HYCOM_tools.fd submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "sorc/HYCOM_tools.fd"]
-	path = sorc/HYCOM_tools.fd
-	url = https://github.com/HYCOM/HYCOM-tools.git
-	branch = master
 [submodule "sorc/ufs_model.fd"]
 	path = sorc/ufs_model.fd
 	url = https://github.com/ufs-community/ufs-weather-model.git


### PR DESCRIPTION
This PR removes HYCOM_tools as a submodule of RTOFS_GLO. Why?

See ⬇️ that has been copy/pasted from https://github.com/NOAA-EMC/RTOFS_GLO/issues/98#issuecomment-3726507221


Here is the major problem:
1. I'm looking into the code delivery requirements. We already have a few bugzilla issues and one of them calls for removal of [about 230 go to statements.](https://github.com/NOAA-EMC/RTOFS_GLO/issues/4#issuecomment-3393746901)
2. If we keep the submodule [HYCOM_tools.fd](https://github.com/NOAA-EMC/RTOFS_GLO/tree/develop/sorc) at `sorc` then 
3. It will add **2402** go to statements! 😢 

```
santha.akella@dlogin02:~> cd my_stmp
santha.akella@dlogin02:~/my_stmp> ls
santha.akella@dlogin02:~/my_stmp> git clone git@github.com:HYCOM/HYCOM-tools.git
Cloning into 'HYCOM-tools'...
remote: Enumerating objects: 2357, done.
remote: Counting objects: 100% (234/234), done.
remote: Compressing objects: 100% (134/134), done.
remote: Total 2357 (delta 134), reused 115 (delta 98), pack-reused 2123 (from 1)
Receiving objects: 100% (2357/2357), 4.23 MiB | 17.00 MiB/s, done.
Resolving deltas: 100% (1408/1408), done.
Updating files: 100% (1541/1541), done.
santha.akella@dlogin02:~/my_stmp> ls
HYCOM-tools
santha.akella@dlogin02:~/my_stmp> cd HYCOM-tools/
```

See ⬇️ 
```
santha.akella@dlogin02:~/my_stmp/HYCOM-tools> grep -rEi "go\s*to" . | wc -l
2402
```

4. To avoid trouble, we should really remove the `HYCOM_tools` submodule.

The only **reference(s)** to HYCOM_tools is in `scripts/to_revive_hycom/` which can be deleted once RTOFS v3 is declared operational.