### PR TITLE
add the word FATAL or WARNING to messages

### DIFF
--- a/scripts/exrtofs_glo_grib2_post.sh
+++ b/scripts/exrtofs_glo_grib2_post.sh
@@ -197,7 +197,7 @@ do
       sleep 10
       icnt=$((icnt + 1))
       if [ $icnt -ge $icnt_max ]; then
-       echo Post timed out arfile_tplate unavailable after $icnt_max iterations
+       echo FATAL: Post timed out arfile_tplate unavailable after $icnt_max iterations
         echo "NOTdone" >${RUN}_${modID}.t${mycyc}z.nav.log
         export err=2; err_chk
       fi
@@ -225,7 +225,7 @@ do
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.archs.a archv.a
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.archs.b archv.b
    else
-    echo "Missing archs file $COMIN/${arfile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
+    echo "FATAL - Missing archs file $COMIN/${arfile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
     echo "NOTdone due to missing archs file" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
   fi
@@ -234,7 +234,7 @@ do
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.arche.a arche.a
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.arche.b arche.b
    else
-    echo "Missing archs file $COMIN/${arefile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
+    echo "FATAL - Missing arche file $COMIN/${arefile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
     echo "NOTdone due to missing arche file" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
   fi
@@ -246,12 +246,12 @@ fi
     if [ ! -f $fn ]
     then
       missing=yes
-      echo "Missing file $fn, will not be able to run" >> ${RUN}_${modID}.t${mycyc}z.nav.log
+      echo "FATAL - Missing file $fn, will not be able to run" >> ${RUN}_${modID}.t${mycyc}z.nav.log
     fi
   done
   if [ $missing = 'yes' ]
   then
-    echo Cannot run due to missing files.
+    echo FATAL - Cannot run due to missing files.
     echo "NOTdone" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
     exit

--- a/scripts/exrtofs_glo_post.sh
+++ b/scripts/exrtofs_glo_post.sh
@@ -156,7 +156,7 @@ do
       icnt=$((icnt + 1))
       if [ $icnt -ge $icnt_max ]
       then
-        echo Post timed out, arfile_tplate not available after $icnt_max iterations.
+        echo FATAL: Post timed out, arfile_tplate not available after $icnt_max iterations.
         echo "NOTdone" >${RUN}_${modID}.t${mycyc}z.nav.log
         export err=2; err_chk
       fi
@@ -171,7 +171,7 @@ do
     ln -s -f $COMIN/${arfile_tplate}.a archv.a
     ln -s -f $COMIN/${arfile_tplate}.b archv.b
   else
-    echo Missing archv file $COMIN/${arfile_tplate}.
+    echo FATAL - Missing archv file $COMIN/${arfile_tplate}.
     echo "NOTdone due to missing archv file" >${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk  
   fi
@@ -181,12 +181,12 @@ do
     if [ ! -f $fn ]
     then
       missing=yes
-      echo Missing file $fn, will not be able to run
+      echo FATAL - Missing file $fn, will not be able to run
     fi
   done
   if [ $missing = 'yes' ]
   then
-    echo Cannot run due to missing files.
+    echo FATAL - Cannot run due to missing files.
     echo "NOTdone" >${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
     exit

--- a/scripts/exrtofs_glo_post_2.sh
+++ b/scripts/exrtofs_glo_post_2.sh
@@ -169,7 +169,7 @@ do
       sleep 10
       icnt=$((icnt + 1))
       if [ $icnt -ge $icnt_max ]; then
-       echo Post timed out arfile_tplate unavailable after $icnt_max iterations
+       echo FATAL: Post timed out arfile_tplate unavailable after $icnt_max iterations
         echo "NOTdone" >${RUN}_${modID}.t${mycyc}z.nav.log
         export err=2; err_chk
       fi
@@ -197,7 +197,7 @@ do
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.archs.a archv.a
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.archs.b archv.b
    else
-    echo "Missing archs file $COMIN/${arfile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
+    echo "FATAL - Missing archs file $COMIN/${arfile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
     echo "NOTdone due to missing archs file" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
   fi
@@ -206,7 +206,7 @@ do
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.arche.a arche.a
      ln -s -f $COMIN/${RUN}_${modID}.t${mycyc}z.n-24.arche.b arche.b
    else
-    echo "Missing archs file $COMIN/${arefile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
+    echo "FATAL - Missing arche file $COMIN/${arefile_tplate}." >>${RUN}_${modID}.t${mycyc}z.nav.log
     echo "NOTdone due to missing arche file" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
   fi
@@ -219,12 +219,12 @@ fi
     if [ ! -f $fn ]
     then
       missing=yes
-      echo "Missing file $fn, will not be able to run" >> ${RUN}_${modID}.t${mycyc}z.nav.log
+      echo "FATAL - Missing file $fn, will not be able to run" >> ${RUN}_${modID}.t${mycyc}z.nav.log
     fi
   done
   if [ $missing = 'yes' ]
   then
-    echo Cannot run due to missing files.
+    echo FATAL - Cannot run due to missing files.
     echo "NOTdone" >>${RUN}_${modID}.t${mycyc}z.nav.log
     export err=1; err_chk
     exit

--- a/ush/rtofs_atmforcing_getges.sh
+++ b/ush/rtofs_atmforcing_getges.sh
@@ -2552,7 +2552,7 @@ if [[ $($ndate 0 $valid 2>/dev/null) != $valid ]];then
  exit 2
 fi
 if [[ -z $geslist ]];then
- echo getges.sh: filetype $typef or resolution $resol not recognized >&2
+ echo getges.sh: WARNING - filetype $typef or resolution $resol not recognized >&2
  exit 2
 fi
 

--- a/ush/rtofs_ncoda_amsr_qc.sh
+++ b/ush/rtofs_ncoda_amsr_qc.sh
@@ -101,7 +101,7 @@ echo timecheck amsr finish ncdump at $(date)
 
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No AMSR files to process."
-   echo "AMSR.obs_control file will not be updated"
+   echo "WARNING - AMSR.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for AMSR netCDF files

--- a/ush/rtofs_ncoda_goes_qc.sh
+++ b/ush/rtofs_ncoda_goes_qc.sh
@@ -124,7 +124,7 @@ echo timecheck goes finish ncdump at $(date)
 
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No GOES files to process."
-   echo "GOES.obs_control file will not be updated"
+   echo "WARNING - GOES.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for GOES netCDF files

--- a/ush/rtofs_ncoda_himawari_qc.sh
+++ b/ush/rtofs_ncoda_himawari_qc.sh
@@ -114,7 +114,7 @@ echo timecheck himawari finish ncdump at $(date)
 
 if [[  ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No HIMAWARI files to process."
-   echo "HIMAWARI.obs_control file will not be updated"
+   echo "WARNING - HIMAWARI.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for HIMAWARI netCDF files

--- a/ush/rtofs_ncoda_ice_qc.sh
+++ b/ush/rtofs_ncoda_ice_qc.sh
@@ -105,7 +105,7 @@ cd $log_dir
 cat ssmi_*.$cut_dtg > ssmi_files.$cut_dtg
 if [[ ! -f ssmi_files.$cut_dtg || ! -s ssmi_files.$cut_dtg ]]; then
    echo "WARNING - ssmi_files.$cut_dtg does not exist/is empty. No SSMI files to process."
-   echo "SSMI.obs_control file will not be updated"
+   echo "WARNING - SSMI.obs_control file will not be updated"
 fi
 
 cat amsr_*.${cut_dtg}_prelim > amsr_ice_files.${cut_dtg}_prelim
@@ -126,7 +126,7 @@ echo timecheck amsr_ice finish ncdump at $(date)
 
 if [[ ! -f amsr_ice_files.$cut_dtg || ! -s amsr_ice_files.$cut_dtg ]]; then
    echo "WARNING - amsr_ice_files.$cut_dtg does not exist/is empty. No AMSR_ICE files to process."
-   echo "AMSR_ICE.obs_control file will not be updated"
+   echo "WARNING - AMSR_ICE.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for ICE netCDF files

--- a/ush/rtofs_ncoda_jpss_qc.sh
+++ b/ush/rtofs_ncoda_jpss_qc.sh
@@ -115,7 +115,7 @@ echo timecheck noaa finish ncdump at $(date)
 
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No VIIRS JPSS files to process."
-   echo "JPSS_VIIRS.obs_control file will not be updated"
+   echo "WARNING - NOAA_VIIRS.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for JPSS netCDF files

--- a/ush/rtofs_ncoda_metop_qc.sh
+++ b/ush/rtofs_ncoda_metop_qc.sh
@@ -128,7 +128,7 @@ echo timecheck metop finish ncdump at $(date)
 
 if [[ ! -f  acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No METOP files to process."
-   echo "METOP.obs_control file will not be updated"
+   echo "WARNING - METOP.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for METOP netCDF files

--- a/ush/rtofs_ncoda_msg_qc.sh
+++ b/ush/rtofs_ncoda_msg_qc.sh
@@ -115,7 +115,7 @@ echo timecheck msg finish ncdump at $(date)
 
 if [[ ! -f  acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No MSG files to process."
-   echo "MSG.obs_control file will not be updated"
+   echo "WARNING - MSG.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for MSG netCDF files

--- a/ush/rtofs_ncoda_npp_qc.sh
+++ b/ush/rtofs_ncoda_npp_qc.sh
@@ -102,7 +102,7 @@ echo timecheck npp finish ncdump at $(date)
 
 if [[ ! -f acspo_sst_files.$cut_dtg || ! -s acspo_sst_files.$cut_dtg ]]; then
    echo "WARNING - acspo_sst_files.$cut_dtg does not exist/is empty. No VIIRS NPP files to process."
-   echo "NPP_VIIRS.obs_control file will not be updated"
+   echo "WARNING - NPP_VIIRS.obs_control file will not be updated"
 fi
 
 #   execute ncoda pre_qc for NPP netCDF files

--- a/ush/rtofs_ncoda_sss_qc.sh
+++ b/ush/rtofs_ncoda_sss_qc.sh
@@ -141,7 +141,7 @@ if [[ ! -f smap_sss_files.$cut_dtg || ! -s smap_sss_files.$cut_dtg ]]; then
    echo "WARNING - smap_sss_files.$cut_dtg does not exist/is empty. No SMAP files to process."
 fi
 if [[ ! -f smos_sss_files.$cut_dtg || ! -s smos_sss_files.$cut_dtg ]] && [[ ! -f smap_sss_files.$cut_dtg || ! -s smap_sss_files.$cut_dtg ]]; then
-   echo "SSS.obs_control file will not be updated"
+   echo "WARNING - SSS.obs_control file will not be updated"
 fi
 #   execute ncoda pre_qc for SSS netCDF files
 $EXECrtofs/rtofs_ncoda_sat_sss_nc $cut_dtg 24 > sss_preqc.$cut_dtg.out


### PR DESCRIPTION
Changes to messaging (add FATAL) for github issues [76](https://github.com/NOAA-EMC/RTOFS_GLO/issues/76), [78](https://github.com/NOAA-EMC/RTOFS_GLO/issues/78) and [108](https://github.com/NOAA-EMC/RTOFS_GLO/issues/108).

Does not resolve 2nd part of issue 76 pertaining to ush/rtofs_atmforcing.sh on errors with a corrupt grib file. 
This part of the code may not be around in new pre steps in v3.0.