### PR TITLE
Add UFS_UTILS as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "sorc/ufs_model.fd"]
 	path = sorc/ufs_model.fd
 	url = https://github.com/ufs-community/ufs-weather-model.git
+[submodule "sorc/ufs_utils.fd"]
+	path = sorc/ufs_utils.fd
+	url = https://github.com/ufs-community/UFS_UTILS


### PR DESCRIPTION
This is necessary for combination of files generated via `IO_LAYOUT`.

To build [UFS_UTILS](https://github.com/ufs-community/UFS_UTILS), for now follow the steps listed [here.](https://github.com/ufs-community/UFS_UTILS?tab=readme-ov-file#installing)

Eventually we will have to a single `build_all.sh` for **EVERYTHING UNDER sorc/**.