### PR TITLE
Ice fields should be renamed as in RTOFS v2.5

### DIFF
--- a/ush/rtofs_ice_change_varNames.sh
+++ b/ush/rtofs_ice_change_varNames.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Goal: Rename variables in the 2D ice netcdf file
+# Goal: Rename variables in the 2D ice netcdf file.
 # Why?  CICE is writing variables with "old_name".
 #       Renaming maintains continuity (for sake of downstream users) with RTOFS v2.5.
+#
+# Note: Input file is modified "in-place", i.e., there is NO NEW OUTPUT file.
 # ----
 
 # Define variable renaming map ( [old_name]="new_name" )
@@ -15,18 +17,16 @@ declare -A var_map=(
     ["vvel_h"]="ice_vvelocity"
 )
 
-# 1. Check if exactly 4 arguments are provided
-if [[ $# -ne 4 ]]; then
+# 1. Check if exactly 2 arguments are provided
+if [[ $# -ne 2 ]]; then
     echo "ERROR: Missing required arguments."
-    echo "Usage: $0 <input_path> <hour_str> <output_path> <output_filename>"
+    echo "Usage: $0 <input_path> <hour_str>"
     exit 1
 fi
 
 # 2. Input Arguments
 IN_PATH=$1
 HOUR_STR=$2
-OUT_PATH=$3
-OUT_FNAME=$4
 
 # 3. File Template Configuration
 prefix="rtofs_glo_2ds."
@@ -41,19 +41,8 @@ if [[ ! -s "$full_inpath" ]]; then
     exit 1
 fi
 
-# 5. Output Setup
-mkdir -p "$OUT_PATH"
-final_output="${OUT_PATH}/${OUT_FNAME}"
-
-echo ">>> Copying to base file: $final_output"
-cp "$full_inpath" "$final_output"
-if [[ $? -ne 0 ]]; then
-    echo "ERROR: Failed to copy input file to output path."
-    exit 1
-fi
-
-# 6. Renaming Block
-echo ">>> Finalizing Variable Names..."
+# 5. Renaming Block (In-Place)
+echo ">>> Finalizing Variable Names in-place..."
 
 # Build the ncrename arguments dynamically from the map
 rename_args=""
@@ -61,21 +50,21 @@ for old_var in "${!var_map[@]}"; do
     rename_args+="-v ${old_var},${var_map[$old_var]} "
 done
 
-# Execute ncrename with the dynamically built flags
-ncrename ${rename_args} "$final_output"
+# Execute ncrename with the dynamically built flags directly on the input file
+ncrename ${rename_args} "$full_inpath"
 
 if [[ $? -eq 0 ]]; then 
-    echo "  [RENAME] Ice variables renamed successfully."
+    echo "  [RENAME] Ice variables finished successfully."
 else
-    echo "ERROR: ncrename failed."
+    echo "  [RENAME] Ice variables failed in ncrename."
     exit 1
 fi
 
-# Final verification to ensure the output file is not empty
-if [[ ! -s "$final_output" ]]; then
-    echo "ERROR: Output file $final_output is missing or 0 bytes after renaming."
+# Final verification to ensure the file is not empty
+if [[ ! -s "$full_inpath" ]]; then
+    echo "ERROR: File $full_inpath is missing or 0 bytes after renaming."
     exit 1
 fi
 
-echo ">>> SUCCESS! Renamed file saved: $final_output"
+echo ">>> SUCCESS! In-place renamed file: $full_inpath"
 exit 0

--- a/ush/rtofs_ice_change_varNames.sh
+++ b/ush/rtofs_ice_change_varNames.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Goal: Rename variables in the 2D ice netcdf file
+# Why?  CICE is writing variables with "old_name".
+#       Renaming maintains continuity (for sake of downstream users) with RTOFS v2.5.
+# ----
+
+# Define variable renaming map ( [old_name]="new_name" )
+# Change these values anytime without altering the logic below
+declare -A var_map=(
+    ["hi_h"]="ice_thickness"
+    ["Tsfc_h"]="ice_temperature"
+    ["aice_h"]="ice_coverage"
+    ["uvel_h"]="ice_uvelocity"
+    ["vvel_h"]="ice_vvelocity"
+)
+
+# 1. Check if exactly 4 arguments are provided
+if [[ $# -ne 4 ]]; then
+    echo "ERROR: Missing required arguments."
+    echo "Usage: $0 <input_path> <hour_str> <output_path> <output_filename>"
+    exit 1
+fi
+
+# 2. Input Arguments
+IN_PATH=$1
+HOUR_STR=$2
+OUT_PATH=$3
+OUT_FNAME=$4
+
+# 3. File Template Configuration
+prefix="rtofs_glo_2ds."
+suffix=".ice.nc"
+infile="${prefix}${HOUR_STR}${suffix}"
+full_inpath="${IN_PATH}/${infile}"
+
+# 4. Verification Step
+echo ">>> Verifying input file in $IN_PATH..."
+if [[ ! -s "$full_inpath" ]]; then
+    echo "ERROR: File $full_inpath is missing or 0 bytes."
+    exit 1
+fi
+
+# 5. Output Setup
+mkdir -p "$OUT_PATH"
+final_output="${OUT_PATH}/${OUT_FNAME}"
+
+echo ">>> Copying to base file: $final_output"
+cp "$full_inpath" "$final_output"
+if [[ $? -ne 0 ]]; then
+    echo "ERROR: Failed to copy input file to output path."
+    exit 1
+fi
+
+# 6. Renaming Block
+echo ">>> Finalizing Variable Names..."
+
+# Build the ncrename arguments dynamically from the map
+rename_args=""
+for old_var in "${!var_map[@]}"; do
+    rename_args+="-v ${old_var},${var_map[$old_var]} "
+done
+
+# Execute ncrename with the dynamically built flags
+ncrename ${rename_args} "$final_output"
+
+if [[ $? -eq 0 ]]; then 
+    echo "  [RENAME] Ice variables renamed successfully."
+else
+    echo "ERROR: ncrename failed."
+    exit 1
+fi
+
+# Final verification to ensure the output file is not empty
+if [[ ! -s "$final_output" ]]; then
+    echo "ERROR: Output file $final_output is missing or 0 bytes after renaming."
+    exit 1
+fi
+
+echo ">>> SUCCESS! Renamed file saved: $final_output"
+exit 0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -27,6 +27,7 @@ export wgrib2_ver=2.0.8
 export evs_ver=2.0_py312
 
 export nco_ver=5.2.4
+export udunits_ver=2.2.28
 
 module use /apps/dev/modulefiles/
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -26,5 +26,7 @@ export wgrib2_ver=2.0.8
 
 export evs_ver=2.0_py312
 
+export nco_ver=5.2.4
+
 module use /apps/dev/modulefiles/
 


### PR DESCRIPTION
# What problem does this PR solve?
- See the names of fields in RTOFS v2.5 sea ice output.
- 2 Examples follow for `forecast` and `nowcast` output files in that order.
1. ncdump -h /lfs/h1/ops/prod/com/rtofs/v2.5/rtofs.20260421/rtofs_glo_2ds_f001_ice.nc | grep 'float'
```
	float Latitude(Y, X) ;
	float Longitude(Y, X) ;
	float ice_coverage(MT, Y, X) ;
	float ice_temperature(MT, Y, X) ;
	float ice_thickness(MT, Y, X) ;
	float ice_uvelocity(MT, Y, X) ;
	float ice_vvelocity(MT, Y, X) ;
```
2. The same output is obtained for a nowcast file: `/lfs/h1/ops/prod/com/rtofs/v2.5/rtofs.20260421/rtofs_glo_2ds_n001_ice.nc`.

- With RTOFS `v3`, we need the **same** names for fields, whereas we get (from the CICE version 6/UFS):

```
ncdump -h rtofs_glo_2ds.f001.ice.nc | grep 'float'
	float TLON(nj, ni) ;
	float TLAT(nj, ni) ;
	float ULON(nj, ni) ;
	float ULAT(nj, ni) ;
	float hi_h(time, nj, ni) ;
	float Tsfc_h(time, nj, ni) ;
	float aice_h(time, nj, ni) ;
	float uvel_h(time, nj, ni) ;
	float vvel_h(time, nj, ni) ;
```

# This PR provides a utility that renames the above `v3` variables to be the same as in `v2.5`.

# Example use:
- `rtofs_ice_change_varNames.sh /lfs/h2/emc/stmp/santha.akella/tmp2 f001`
- With no arguments, echoes usage:
```
rtofs_ice_change_varNames.sh
ERROR: Missing required arguments.
Usage: /lfs/h2/emc/couple/noscrub/santha.akella/ice_rename/ush/rtofs_ice_change_varNames.sh <input_path> <hour_str>
```
# Proof that it works:
```
ncdump -h rtofs_glo_2ds.tm029.ice.nc | grep 'float'
	float TLON(nj, ni) ;
	float TLAT(nj, ni) ;
	float ULON(nj, ni) ;
	float ULAT(nj, ni) ;
	float ice_thickness(time, nj, ni) ;
	float ice_temperature(time, nj, ni) ;
	float ice_coverage(time, nj, ni) ;
	float ice_uvelocity(time, nj, ni) ;
	float ice_vvelocity(time, nj, ni) ;
```
# Questions/notes for @DanIredell-NOAA:
- Looking at the additions/modifications to the workflow: `scripts/exrtofs_glo_analysis.sh` and `scripts/exrtofs_glo_forecast.sh`
- Can this `ush/rtofs_ice_change_varNames.sh` be called from within the above `exrtofs_glo_analysis.sh` and `exrtofs_glo_forecast.sh`?
- I added modules `nco` and `udunits` to `versions/run.ver`
- Tested (offline) with: `ml intel udunits/2.2.28 nco/5.2.4`

