### PR TITLE
Mod to RTOFS V2.5 for GFS V17 (location of directory of the sflux files)

### DIFF
--- a/ush/rtofs_atmforcing_getges.sh
+++ b/ush/rtofs_atmforcing_getges.sh
@@ -256,7 +256,7 @@ if [[ $netwk = gdas ]];then
    fhinc=01
    ;;
   sfcflxfv3) geslist='
-   $GETGES_COM/gdas.$day/${cyc}/atmos/gdas.t${cyc}z.sfluxgrbf${fh3}.grib2'
+   $GETGES_COM/gdas.$day/${cyc}/model/atmos/master/gdas.t${cyc}z.sflux.f${fh3}.grib2'
    fhinc=01
    ;;
   pgbges) geslist='
@@ -432,7 +432,7 @@ elif [[ $netwk = gfs ]];then
    $GETGES_COM/gfs/$envirges/gfs.$day/gfs.t${cyc}z.sfluxgrbf${fh}.grib2'
    ;;
   sfcflxfv3) geslist='
-   $GETGES_COM/gfs.$day/${cyc}/atmos/gfs.t${cyc}z.sfluxgrbf${fh3}.grib2'
+   $GETGES_COM/gfs.$day/${cyc}/model/atmos/master/gfs.t${cyc}z.sflux.f${fh3}.grib2'
    ;;
   pgbges) geslist='
    $GETGES_COM/gfs/$envirges/gfs.$day/gfs.t${cyc}z.pgrbf$fh'
@@ -605,7 +605,7 @@ elif [[ $netwk = gfs ]];then
    $GETGES_COM/gfs/$envirges/gfs.$day/gfs.t${cyc}z.sfluxgrbf${fh}.grib2'
    ;;
   sfcflxfv3) geslist='
-   $GETGES_COM/gfs/${envirges}/gfs.$day/${cyc}/atmos/gfs.t${cyc}z.sfluxgrbf${fh3}.grib2'
+   $GETGES_COM/gfs/${envirges}/gfs.$day/${cyc}/model/atmos/master/gfs.t${cyc}z.sflux.f${fh3}.grib2'
    ;;
   pgbges) geslist='
    $GETGES_COM/gfs/$envirges/gfs.$day/gfs.t${cyc}z.pgrbf$fh'


### PR DESCRIPTION
The location and the filename changes for GFS V17.  Modification needed to the getges script to find this new location and name.  This is reference to github issue [92](https://github.com/NOAA-EMC/RTOFS_GLO/issues/92)
