### PR TITLE
Consolidating clone and build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,37 @@ The global-workflow depends on the following prerequisities to be available on t
 RTOFS-GLO current supports the following machines:
 
 * WCOSS2
+* [NOAA RDHPCS](https://docs.rdhpcs.noaa.gov/systems/index.html#): Gaea C6, MSU-HPC, Ursa for forecast model only.
 
 ## Building RTOFS:
 
-### 1. Check out components
+### 1. Base check out
 
-$ git clone git@github.com:NOAA-EMC/RTOFS_GLO.git
+```
+git clone git@github.com:NOAA-EMC/RTOFS_GLO.git
+cd RTOFS_GLO/sorc
+```
 
-While in /sorc folder (require access to NCODA repository):
+**Note**:
+- If you have no intention to develop anything and want to merely use RTOFS, see below.
+- Instead of clone using: `git clone git@github.com:NOAA-EMC/RTOFS_GLO.git`,
+- Do: `git clone https://github.com/NOAA-EMC/RTOFS_GLO.git`
+
+### 2. Build components
+
+- Forecast model:
+  - Use `./build_forecast.sh` <RUN_ENVIR> <machine_name>
+  - Notes:
+    - Allowed `RUN_ENVIR`= nco, emc.
+    - `machine_name` = wcoss2, ursa, orion, gaeac6.
+    - For all development on WCOSS-2: `./build_forecast.sh emc wcoss2`
+
+
+- NCODA DA (**requires access to NCODA repository**):
+    
 ```
 $ git clone git@github.com:NOAA-EMC/NCODA.git rtofs_ncoda.fd
 ```
-### 2. Build components
 
 While in /libs folder:
 ```

--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ cd RTOFS_GLO/sorc
      - Allowed `RUN_ENVIR`= nco, emc.
      - `machine_name` = wcoss2, ursa, orion, gaeac6.
      - For all development on WCOSS-2: `./build_forecast.sh emc wcoss2`
+       - Other than WCOSS-2: `./build_forecast.sh emc <machine_name>`
 
 2. Rest of the utilities, including NCODA (**requires access to NCODA repository**), on wcoss2 only:
    - Use `build_ncoda_and_rtofs_utils.sh <machine_name>`
    - Notes:
      - Allowed `machine_name`= wcoss2 (only).
+     - Relies on `sorc/build_rtofs.sh`.
+
+**Remarks**:
+- If building NCODA only, use: `sorc/build_rtofs_ncoda.sh`
 

--- a/README.md
+++ b/README.md
@@ -22,32 +22,19 @@ cd RTOFS_GLO/sorc
 **Note**:
 - If you have no intention to develop anything and want to merely use RTOFS, see below.
 - Instead of clone using: `git clone git@github.com:NOAA-EMC/RTOFS_GLO.git`,
-- Do: `git clone https://github.com/NOAA-EMC/RTOFS_GLO.git`
+- Do: `git clone https://github.com/NOAA-EMC/RTOFS_GLO.git`.
 
 ### 2. Build components
 
-- Forecast model:
-  - Use `./build_forecast.sh` <RUN_ENVIR> <machine_name>
-  - Notes:
-    - Allowed `RUN_ENVIR`= nco, emc.
-    - `machine_name` = wcoss2, ursa, orion, gaeac6.
-    - For all development on WCOSS-2: `./build_forecast.sh emc wcoss2`
+1. Forecast model:
+   - Use `./build_forecast.sh` <RUN_ENVIR> <machine_name>
+   - Notes:
+     - Allowed `RUN_ENVIR`= nco, emc.
+     - `machine_name` = wcoss2, ursa, orion, gaeac6.
+     - For all development on WCOSS-2: `./build_forecast.sh emc wcoss2`
 
-
-- NCODA DA (**requires access to NCODA repository**):
-    
-```
-$ git clone git@github.com:NOAA-EMC/NCODA.git rtofs_ncoda.fd
-```
-
-While in /libs folder:
-```
-$ ./build_libs.sh
-```
-
-While in /sorc folder:
-```
-$ ./build_rtofs.sh
-$ ./build_rtofs.sh install
-```
+2. Rest of the utilities, including NCODA (**requires access to NCODA repository**), on wcoss2 only:
+   - Use `build_ncoda_and_rtofs_utils.sh <machine_name>`
+   - Notes:
+     - Allowed `machine_name`= wcoss2 (only).
 

--- a/sorc/build_forecast.sh
+++ b/sorc/build_forecast.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Build the UFS and UFS_UTILS
+
+# 0. Input Arguments
+if [[ $# -ne 2 ]]; then
+    echo "ERROR: Missing required arguments."
+    echo "Usage: $0 <RUN_ENVIR> <machine_name>"
+    echo "Options for RUN_ENVIR: emc, nco"
+    echo "Options for machine_name: wcoss2, ursa, orion, gaeac6"
+    exit 1
+fi
+
+RUN_ENVIR=$1
+MACHINE=$2
+echo ">>> Target RUN_ENVIR set to: $RUN_ENVIR"
+echo ">>> Target machine set to: $MACHINE"
+
+set -eux
+
+cd ..
+
+# 1. Clone UFS-weather-model (and update submodules) and UFS_UTILS (for mppnccombine)
+git submodule update --init --recursive
+
+# Ensure top-level exec directory exists
+mkdir -p exec
+TOP_EXEC="$(pwd)/exec"
+
+# 2. Setup and build ufs_utils
+echo ">>> Building ufs_utils for $RUN_ENVIR on $MACHINE..."
+cd sorc/ufs_utils.fd/fix
+./link_fixdirs.sh "$RUN_ENVIR" "$MACHINE"
+cd ..
+./build_all.sh
+
+# Sanity check: verify mppnccombine was built and is executable
+if [[ ! -x "exec/mppnccombine" ]]; then
+    echo "ERROR: exec/mppnccombine was not generated or is not executable."
+    exit 1
+fi
+cp exec/mppnccombine "$TOP_EXEC/"
+cd ../..
+
+# 3. Build UFS
+echo ">>> Building UFS..."
+cd scripts/pre/
+./compile_ufs.sh 
+
+# Return to top-level BEFORE checking the sorc/ relative path
+cd ../..
+
+# Sanity check: verify ufs_model.x was built and is executable
+if [[ ! -x "sorc/ufs_model.fd/tests/ufs_model.x" ]]; then
+    echo "ERROR: sorc/ufs_model.fd/tests/ufs_model.x was not generated or is not executable."
+    exit 2
+fi
+cp sorc/ufs_model.fd/tests/ufs_model.x "$TOP_EXEC/"
+
+# 4. Final verification
+echo ">>> Verifying final executables..."
+if [[ ! -x "exec/mppnccombine" || ! -x "exec/ufs_model.x" ]]; then
+    echo "ERROR: Executables failed to copy to the top-level exec/ directory."
+    exit 3
+fi
+
+echo ">>> SUCCESS! Build of forecast model is complete and executables verified."
+exit 0

--- a/sorc/build_ncoda_and_rtofs_utils.sh
+++ b/sorc/build_ncoda_and_rtofs_utils.sh
@@ -11,20 +11,44 @@ if [[ $# -ne 1 ]]; then
 fi
 
 MACHINE=$1
+
+# Exit if machine is not exactly "wcoss2"
+if [[ "$MACHINE" != "wcoss2" ]]; then
+    echo "ERROR: Unsupported machine '$MACHINE', currently supported on 'wcoss2' only."
+    exit 1
+fi
+
 echo ">>> Target machine set to: $MACHINE"
 # Exporting MACHINE in case the underlying scripts rely on it as an environment variable
 export MACHINE
 
 set -eux
 
-# 1. Build Libraries
+# 1. Build Libraries/Utilities
 echo ">>> Building libraries..."
 cd ../libs
 ./build_libs.sh
-
-# 2. Build and Install RTOFS
-echo ">>> Building and installing RTOFS model..."
 cd ../sorc
+
+# 2. Build and Install NCODA
+echo ">>> Building and installing RTOFS model..."
+
+# 2.1 Clone NCODA
+echo ">>> Cloning NCODA repository..."
+if [[ ! -d "rtofs_ncoda.fd" ]]; then
+   git clone git@github.com:NOAA-EMC/NCODA.git rtofs_ncoda.fd
+else
+   echo ">>> rtofs_ncoda.fd already exists, skipping clone."
+fi
+
+# 2.2 Setup fix directory symlink
+# Moving up to the directory above to create the link
+cd ..
+echo ">>> Linking fix directory..."
+# The -n flag ensures it doesn't nest the link if run multiple times
+ln -sfn /lfs/h2/emc/couple/noscrub/dan.iredell/RTOFSFIX/20260219/fix/ fix
+
+cd sorc
 ./build_rtofs.sh || { echo "ERROR: build_rtofs.sh failed."; exit 1; }
 ./build_rtofs.sh install || { echo "ERROR: build_rtofs.sh install failed."; exit 1; }
 

--- a/sorc/build_ncoda_and_rtofs_utils.sh
+++ b/sorc/build_ncoda_and_rtofs_utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Build NCODA and RTOFS specific utilities
+
+# 0. Input Arguments
+if [[ $# -ne 1 ]]; then
+    echo "ERROR: Missing required argument."
+    echo "Usage: $0 <machine_name>"
+    echo "Example: $0 wcoss2"
+    exit 1
+fi
+
+MACHINE=$1
+echo ">>> Target machine set to: $MACHINE"
+# Exporting MACHINE in case the underlying scripts rely on it as an environment variable
+export MACHINE
+
+set -eux
+
+# 1. Build Libraries
+echo ">>> Building libraries..."
+cd ../libs
+./build_libs.sh
+
+# 2. Build and Install RTOFS
+echo ">>> Building and installing RTOFS model..."
+cd ../sorc
+./build_rtofs.sh || { echo "ERROR: build_rtofs.sh failed."; exit 1; }
+./build_rtofs.sh install || { echo "ERROR: build_rtofs.sh install failed."; exit 1; }
+
+echo ">>> SUCCESS! Built NCODA and RTOFS utilities and installed."
+exit 0

--- a/sorc/build_rtofs.sh
+++ b/sorc/build_rtofs.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # top level script to build / install / clean RTOFS binaries
 
+set -e
+
 if [ $# -lt 1 ] 
 then
   whattodo=compile

--- a/sorc/build_rtofs_ncoda.sh
+++ b/sorc/build_rtofs_ncoda.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Build the NCODA for RTOFS
+
+# 0. Input Arguments
+if [[ $# -ne 1 ]]; then
+    echo "ERROR: Missing required argument."
+    echo "Usage: $0 <machine_name>"
+    echo "Example: $0 wcoss2"
+    exit 1
+fi
+
+MACHINE=$1
+echo ">>> Target machine set to: $MACHINE"
+
+set -eux
+
+# Execute logic ONLY if machine is wcoss2
+if [[ "$MACHINE" == "wcoss2" ]]; then
+    echo ">>> Machine is wcoss2. Proceeding with NCODA build..."
+
+    # 1. Clone NCODA
+    echo ">>> Cloning NCODA repository..."
+    if [[ ! -d "rtofs_ncoda.fd" ]]; then
+        git clone git@github.com:NOAA-EMC/NCODA.git rtofs_ncoda.fd
+    else
+        echo ">>> rtofs_ncoda.fd already exists, skipping clone."
+    fi
+
+    # 2. Setup fix directory symlink
+    # Moving up to the directory above to create the link
+    cd ..
+    echo ">>> Linking fix directory..."
+    # The -n flag ensures it doesn't nest the link if run multiple times
+    ln -sfn /lfs/h2/emc/couple/noscrub/dan.iredell/RTOFSFIX/20260219/fix/ fix
+
+    # 3. Build NCODA
+    echo ">>> Building NCODA..."
+    cd sorc/rtofs_ncoda.fd
+    ./build_ncoda.sh
+
+    # Sanity check
+    if [[ ! -x "rtofs_ncoda" ]]; then
+        echo "ERROR: NCODA build failed to produce the executable (rtofs_ncoda)."
+        exit 1
+    fi
+
+    echo ">>> SUCCESS! NCODA build completed for wcoss2."
+
+else
+    echo ">>> Machine is NOT wcoss2 ($MACHINE). Skipping NCODA build."
+fi
+
+exit 0


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/RTOFS_GLO/issues/131

# How to test?
1. `git clone -b clone_and_build_issue131 git@github.com:NOAA-EMC/RTOFS_GLO.git`
2. Rest: see `README.md`.

## Note: 
 - `./build_forecast.sh emc wcoss2` will work on `acorn` too, replace `wcoss2` with `acorn`.

## Verified it all works as expected on:

| Machine Name | Path to built exec (will be purged after a _few_ days) |
| :-- | --: |
| WCOSS-2 | `/lfs/h1/emc/stmp/santha.akella/RTOFS_GLO/exec` |
| Ursa | `/scratch4/NCEPDEV/marine/Santha.Akella/RTOFS_GLO/exec` |
| gaeac6 | `/ncrc/proj/sfs-cpu/Santha.Akella/RTOFS_GLO/exec/` |
| orion, hercules | `/work/noaa/marine/sakella/RTOFS_GLO/exec/` |

@raphaeldussin:
- Once you have kindly verified that the :arrow_up: works for you on Gaea C6, please approve the PR.
- If it does not work, please leave comments.  

:pray:  
