### PR TITLE
add 2 diags z* coords and diag_table updates, fixes #133

### DIFF
--- a/parm/MOM_input
+++ b/parm/MOM_input
@@ -664,15 +664,21 @@ REMAP_VEL_MASK_BBL_THICK = -0.001 !   [m] default = -0.001
 
 
 ! === module MOM_diag_mediator ===
-NUM_DIAG_COORDS = 1             ! default = 1
+NUM_DIAG_COORDS = 2             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
 !USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
-DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
+DIAG_COORDS = "z33 ZL ZSTAR, z40 ZM ZSTAR"       ! default = "z Z ZSTAR"
                                 ! A list of string tuples associating diag_table modules to a coordinate
                                 ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
                                 ! PARAMETER_SUFFIX COORDINATE_NAME".
+DIAG_COORD_DEF_ZL = "PARAM"
+DIAG_COORD_RES_ZL = 5.,10.,10.,15.,22.5,25.,25.,25.,37.5,50.,50.,75.,100.,100.,100.,100.,100.,100.,100.,100.,100.,100.,100.,175.,250.,375.,500.,500.,500.,500.,500.,500.,750.
+DIAG_COORD_DEF_ZM = "PARAM"
+DIAG_COORD_RES_ZM = 1.,2.,2.,2.,2.,2.,2.5,4.,5.,5.,5.,5.,5.,5.,7.5,10.,10.,10.,10.,17.5,25.,37.5,50.,50.,50.,50.,75.,100.,100.,100.,100.,100.,175.,250.,375.,500.,500.,750.,1000.,1500.
+
+
 DIAG_MISVAL = 1.0E+20           !   [various] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False

--- a/parm/diag_table
+++ b/parm/diag_table
@@ -20,6 +20,19 @@
 "ocn3zuio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
 "ocn3zvio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
 "ocn3zhio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+
+"ocnglo3zsio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3ztio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zuio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zvio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zhio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+
+#"ocnUSe3zsio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3ztio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zuio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zvio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zhio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+
 "ocnp%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
 "ocns%4yr_%3dy_%2hr", 1,"hours", 1, "days","Time", 1,"hours"
 
@@ -45,6 +58,23 @@
 "ocean_model","uo",     "u",        "ocn3zuio%4yr_%3dy_%2hr","all","none","none",2
 "ocean_model","vo",     "v",        "ocn3zvio%4yr_%3dy_%2hr","all","none","none",2
 "ocean_model","h",      "h",        "ocn3zhio%4yr_%3dy_%2hr","all","none","none",2
+
+# Global fields  (output on 33 z* levels)
+#==============
+"ocean_model_z33","so",     "salt",     "ocnglo3zsio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","thetao", "potT",     "ocnglo3ztio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","uo",     "u",        "ocnglo3zuio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","vo",     "v",        "ocnglo3zvio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","h",      "h",        "ocnglo3zhio%4yr_%3dy_%2hr","all","none","none",2
+
+# Regional fields  (output on 40 z* levels)
+#================
+#"ocean_model_z40","so",     "salt",     "ocnUSe3zsio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","thetao", "potT",     "ocnUSe3ztio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","uo",     "u",        "ocnUSe3zuio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","vo",     "v",        "ocnUSe3zvio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","h",      "h",        "ocnUSe3zhio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+
 
 # Surface Ocean fields:
 #======================

--- a/parm/diag_table.forecast
+++ b/parm/diag_table.forecast
@@ -20,6 +20,19 @@
 "ocn3zuio%4yr_%3dy_%2hr", 12,"hours",  1, "days","Time", 12,"hours"
 "ocn3zvio%4yr_%3dy_%2hr", 12,"hours",  1, "days","Time", 12,"hours"
 "ocn3zhio%4yr_%3dy_%2hr", 12,"hours",  1, "days","Time", 12,"hours"
+
+"ocnglo3zsio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3ztio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zuio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zvio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+"ocnglo3zhio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+
+#"ocnUSe3zsio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3ztio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zuio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zvio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+#"ocnUSe3zhio%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
+
 "ocnp%4yr_%3dy_%2hr", 6,"hours",  1, "days","Time", 6,"hours"
 "ocns%4yr_%3dy_%2hr", 1,"hours", 1, "days","Time", 1,"hours"
 
@@ -45,6 +58,22 @@
 "ocean_model","uo",     "u",        "ocn3zuio%4yr_%3dy_%2hr","all","none","none",2
 "ocean_model","vo",     "v",        "ocn3zvio%4yr_%3dy_%2hr","all","none","none",2
 "ocean_model","h",      "h",        "ocn3zhio%4yr_%3dy_%2hr","all","none","none",2
+
+# Global fields  (output on 33 z* levels)
+#==============
+"ocean_model_z33","so",     "salt",     "ocnglo3zsio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","thetao", "potT",     "ocnglo3ztio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","uo",     "u",        "ocnglo3zuio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","vo",     "v",        "ocnglo3zvio%4yr_%3dy_%2hr","all","none","none",2
+"ocean_model_z33","h",      "h",        "ocnglo3zhio%4yr_%3dy_%2hr","all","none","none",2
+
+# Regional fields  (output on 40 z* levels)
+#================
+#"ocean_model_z40","so",     "salt",     "ocnUSe3zsio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","thetao", "potT",     "ocnUSe3ztio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","uo",     "u",        "ocnUSe3zuio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","vo",     "v",        "ocnUSe3zvio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
+#"ocean_model_z40","h",      "h",        "ocnUSe3zhio%4yr_%3dy_%2hr","all","none","-105.19 -40.72  0.0 79.75 -1 -1",2
 
 # Surface Ocean fields:
 #======================


### PR DESCRIPTION
This PR defines 2 diagnostics z* coords (33 levels for global, 40 level for regional). Adding global field in 33 z* in diag_tables + placeholder for regional output (example for US east, not tested)